### PR TITLE
Ensure _calculateElevation is automatically called.

### DIFF
--- a/demo/paper-button.html
+++ b/demo/paper-button.html
@@ -59,24 +59,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
 
     Polymer({
+      is: 'paper-button',
 
       behaviors: [
         Polymer.PaperButtonBehavior
-      ],
-
-      hostAttributes: {
-        role: 'button'
-      },
-
-      ready: function() {
-        this.raised = true;
-        this._buttonStateChanged();
-      },
-
-      _buttonStateChanged: function() {
-        this._calculateElevation();
-      }
-
+      ]
     });
 
   </script>

--- a/paper-button-behavior.html
+++ b/paper-button-behavior.html
@@ -14,35 +14,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
 
   /** @polymerBehavior */
+  Polymer.PaperButtonBehaviorImpl = {
+
+    properties: {
+
+      _elevation: {
+        type: Number
+      }
+
+    },
+
+    observers: [
+      '_calculateElevation(focused, disabled, active, pressed, receivedFocusFromKeyboard)'
+    ],
+
+    hostAttributes: {
+      role: 'button',
+      tabindex: '0'
+    },
+
+    _calculateElevation: function() {
+      var e = 1;
+      if (this.disabled) {
+        e = 0;
+      } else if (this.active || this.pressed) {
+        e = 4;
+      } else if (this.receivedFocusFromKeyboard) {
+        e = 3;
+      }
+      this._elevation = e;
+    }
+  };
+
   Polymer.PaperButtonBehavior = [
     Polymer.IronButtonState,
     Polymer.IronControlState,
-    {
-      properties: {
-
-        _elevation: {
-          type: Number
-        }
-
-      },
-
-      hostAttributes: {
-        role: 'button',
-        tabindex: '0'
-      },
-
-      _calculateElevation: function() {
-        var e = 1;
-        if (this.disabled || !this.raised) {
-          e = 0;
-        } else if (this.active || this.pressed) {
-          e = 4;
-        } else if (this.receivedFocusFromKeyboard) {
-          e = 3;
-        }
-        this._elevation = e;
-      }
-    }
+    Polymer.PaperButtonBehaviorImpl
   ];
 
 </script>

--- a/paper-radio-button-behavior.html
+++ b/paper-radio-button-behavior.html
@@ -17,19 +17,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer.PaperRadioButtonInk = {
 
     observers: [
-      '_focusedChanged(focused)'
+      '_focusedChanged(receivedFocusFromKeyboard)'
     ],
 
-    _focusedChanged: function(focused) {
-      if (!this.$.ink)
+    _focusedChanged: function(receivedFocusFromKeyboard) {
+      if (!this.$.ink) {
         return;
-
-      if (focused) {
-        var rect = this.$.ink.getBoundingClientRect();
-        this.$.ink.downAction();
-      } else {
-        this.$.ink.upAction();
       }
+
+      this.$.ink.holdDown = receivedFocusFromKeyboard;
     }
 
   };

--- a/test/paper-button-behavior.html
+++ b/test/paper-button-behavior.html
@@ -30,59 +30,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-  <test-fixture id="raised">
-    <template>
-      <test-button raised toggles></test-button>
-    </template>
-  </test-fixture>
-
   <script>
     suite('basic', function() {
       var button;
 
-      suite('when raised is false', function() {
-        setup(function() {
-          button = fixture('basic');
-        });
-
-        test('normal (no states)', function() {
-          assert.equal(button._elevation, 0);
-        });
-
-        test('set disabled property', function() {
-          button.disabled = true;
-          assert.equal(button._elevation, 0);
-        });
-
-        test('activated by tap', function(done) {
-          MockInteractions.downAndUp(button, function() {
-            try {
-              assert.equal(button._elevation, 0);
-              done();
-            } catch (e) {
-              done(e);
-            }
-          });
-        });
-
-        test('receives focused', function() {
-          MockInteractions.focus(button);
-          assert.equal(button._elevation, 0);
-        })
+      setup(function() {
+        button = fixture('basic');
       });
 
-      suite('when raised is true', function() {
+      test('normal (no states)', function() {
+        assert.equal(button._elevation, 1);
+      });
+
+      test('set disabled property', function() {
+        button.disabled = true;
+        assert.equal(button._elevation, 0);
+      });
+
+      test('pressed and released', function() {
+        MockInteractions.down(button);
+        assert.equal(button._elevation, 4);
+        MockInteractions.up(button);
+        assert.equal(button._elevation, 1);
+      });
+
+      suite('a button with toggles', function() {
         setup(function() {
-          button = fixture('raised');
-        });
-
-        test('normal (no states)', function() {
-          assert.equal(button._elevation, 1);
-        });
-
-        test('set disabled property', function() {
-          button.disabled = true;
-          assert.equal(button._elevation, 0);
+          button.toggles = true;
         });
 
         test('activated by tap', function(done) {
@@ -95,13 +69,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           });
         });
-
-        test('receives focused', function() {
-          MockInteractions.focus(button);
-          assert.equal(button._elevation, 2);
-        })
       });
 
+      test('receives focused', function() {
+        MockInteractions.focus(button);
+        assert.equal(button._elevation, 3);
+      });
     });
   </script>
 

--- a/test/test-button.html
+++ b/test/test-button.html
@@ -13,27 +13,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="test-button">
 
+  <template>
+    <content></content>
+  </template>
+
   <script>
 
     Polymer({
 
+      is: 'test-button',
+
       behaviors: [
         Polymer.PaperButtonBehavior
-      ],
-
-      properties: {
-
-        raised: {
-          type: Boolean,
-          value: false,
-          observer: '_buttonStateChanged'
-        }
-
-      },
-
-      _buttonStateChanged: function() {
-        this._calculateElevation();
-      }
+      ]
 
     });
 


### PR DESCRIPTION
I've tried to remove all misleading extra implementation from the test and demo buttons. Please let me know if you spot anything else.

The way this works now is, if you have an extra property in your button that uses this behavior, and that property makes a difference in the elevation, you should override _calculateElevation in your button and proceed accordingly.