### PR TITLE
s/PaperRadioButtonBehavior/PaperInkyFocusBehavior

### DIFF
--- a/demo/paper-radio-button.html
+++ b/demo/paper-radio-button.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../paper-ripple/paper-ripple.html">
-<link rel="import" href="../paper-radio-button-behavior.html">
+<link rel="import" href="../paper-inky-focus-behavior.html">
 
 <dom-module id="paper-radio-button">
 
@@ -98,7 +98,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer({
 
       behaviors: [
-        Polymer.PaperRadioButtonBehavior
+        Polymer.PaperInkyFocusBehavior
       ],
 
       hostAttributes: {

--- a/paper-inky-focus-behavior.html
+++ b/paper-inky-focus-behavior.html
@@ -13,8 +13,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  /** @polymerBehavior */
-  Polymer.PaperRadioButtonInk = {
+  /**
+   * `Polymer.PaperInkyFocusBehavior` implements a ripple when the element has keyboard focus.
+   *
+   * @polymerBehavior Polymer.PaperInkyFocusBehavior
+   */
+  Polymer.PaperInkyFocusBehaviorImpl = {
 
     observers: [
       '_focusedChanged(receivedFocusFromKeyboard)'
@@ -30,11 +34,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   };
 
-  /** @polymerBehavior */
-  Polymer.PaperRadioButtonBehavior = [
+  /** @polymerBehavior Polymer.PaperInkyFocusBehavior */
+  Polymer.PaperInkyFocusBehavior = [
     Polymer.IronButtonState,
     Polymer.IronControlState,
-    Polymer.PaperRadioButtonInk
+    Polymer.PaperInkyFocusBehaviorImpl
   ];
 
 </script>

--- a/test/test-radio-button.html
+++ b/test/test-radio-button.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../paper-radio-button-behavior.html">
+<link rel="import" href="../paper-inky-focus-behavior.html">
 <link rel="import" href="../../paper-ripple/paper-ripple.html">
 
 <dom-module id="test-radio-button">
@@ -35,7 +35,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     is: 'test-radio-button',
 
     behaviors: [
-      Polymer.PaperRadioButtonBehavior
+      Polymer.PaperInkyFocusBehavior
     ]
   });
 </script>


### PR DESCRIPTION
First step towards fixing https://github.com/PolymerElements/paper-behaviors/issues/22

The inky focus state needs to be used by other elements that are not radio buttons (`paper-slider`, `paper-icon-button`), and has nothing to do with actual radio buttons. Past Monica: name things better.