### PR TITLE
Set `holdDown` asynchronously.

### DIFF
--- a/paper-inky-focus-behavior.html
+++ b/paper-inky-focus-behavior.html
@@ -28,8 +28,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!this.$.ink) {
         return;
       }
-
-      this.$.ink.holdDown = receivedFocusFromKeyboard;
+      
+      this.async(function() {
+        this.$.ink.holdDown = receivedFocusFromKeyboard;
+      });
     }
 
   };


### PR DESCRIPTION
`holdDown` requires a rendered ripple, but what if the ripple is not rendered yet? That's is the use case of `paper-slider`. https://github.com/PolymerElements/paper-slider/pull/30

I could have used `visibility: hidden`, but I think `holdDown` should be async.