### PR TITLE
Fixed @polymerBehavior tag so definitions can merge.

### DIFF
--- a/paper-button-behavior.html
+++ b/paper-button-behavior.html
@@ -13,7 +13,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  /** @polymerBehavior */
+  /** 
+   * The `PaperButtonBehavior` implements shared behavior for material design buttons
+   * such as [paper-button](paper-button) and [paper-fab](paper-fab).
+   * 
+   * @polymerBehavior Polymer.PaperButtonBehavior 
+   */
   Polymer.PaperButtonBehaviorImpl = {
 
     properties: {


### PR DESCRIPTION
Right now, two definitions are showing up, on for PaperButtonBehavior and one for PaperButtonBehaviorImpl.

Also, it looks weird with no doc at all. Adding minimal doc string so it looks less broken.