### PR TITLE
add form behaviour

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
     "iron-checked-element-behavior": "PolymerElements/iron-checked-element-behavior#^1.0.0",
+    "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0"
   },
   "devDependencies": {

--- a/paper-button-behavior.html
+++ b/paper-button-behavior.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-behaviors/iron-button-state.html">
+<link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
 <link rel="import" href="paper-ripple-behavior.html">
 
 <script>
@@ -64,7 +65,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
-     * In addition to `IronButtonState` behavior, when space key goes down, 
+     * In addition to `IronButtonState` behavior, when space key goes down,
      * create a ripple down effect.
      */
     _spaceKeyDownHandler: function(event) {
@@ -75,7 +76,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
-     * In addition to `IronButtonState` behavior, when space key goes up, 
+     * In addition to `IronButtonState` behavior, when space key goes up,
      * create a ripple up effect.
      */
     _spaceKeyUpHandler: function(event) {
@@ -92,6 +93,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer.IronButtonState,
     Polymer.IronControlState,
     Polymer.PaperRippleBehavior,
+    Polymer.IronFormElementBehavior,
     Polymer.PaperButtonBehaviorImpl
   ];
 


### PR DESCRIPTION
This gives `paper-button` and `paper-fab` the ability to be tracked by an `iron-form` (and be submitted).

Sample usage:
`<paper-button name="batman" value="awesome></paper-button>`