### PR TITLE
More compile fixes

### DIFF
--- a/paper-ripple-behavior.html
+++ b/paper-ripple-behavior.html
@@ -79,9 +79,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         var domContainer = rippleContainer === this.shadyRoot ? this :
           rippleContainer;
-        if (opt_triggeringEvent &&
-            domContainer.contains(opt_triggeringEvent.target)) {
-          this._ripple.uiDownAction(opt_triggeringEvent);
+        if (opt_triggeringEvent) {
+          var target = opt_triggeringEvent.target;
+          if (domContainer.contains(/** @type {Node} */(target))) {
+            this._ripple.uiDownAction(opt_triggeringEvent);
+          }
         }
       }
     },


### PR DESCRIPTION
/cc @rictic 

without this I'm getting:
```
third_party/polymer/v1_0/components-chromium/paper-behaviors/paper-ripple-behavior-extracted.js:68: ERROR - actual parameter 1 of Node.prototype.contains does not match formal parameter
## found   : (EventTarget|null)
## required: (Node|null)
##             domContainer.contains(opt_triggeringEvent.target)) {
```

no idea why I wasn't getting this error before