### PR TITLE
Merge behavior names to `PaperInkyFocusBehavior`

### DIFF
--- a/paper-inky-focus-behavior.html
+++ b/paper-inky-focus-behavior.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /**
    * `Polymer.PaperInkyFocusBehavior` implements a ripple when the element has keyboard focus.
    *
-   * @polymerBehavior Polymer.PaperInkyFocusBehaviorImpl
+   * @polymerBehavior Polymer.PaperInkyFocusBehavior
    */
   Polymer.PaperInkyFocusBehaviorImpl = {
 


### PR DESCRIPTION
Previously you would get both `PaperInkyFocusBehaviorImpl` and `PaperInkyFocusBehavior` from tools/docs