### PR TITLE
Fix for IE / Opera keyboard focus issue.

### DIFF
--- a/paper-button-behavior.html
+++ b/paper-button-behavior.html
@@ -60,7 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _computeKeyboardClass: function(receivedFocusFromKeyboard) {
-      this.classList.toggle('keyboard-focus', receivedFocusFromKeyboard);
+      this.toggleClass('keyboard-focus', receivedFocusFromKeyboard);
     },
 
     /**


### PR DESCRIPTION
This is a fix for an issue that was reported over on `paper-button`: https://github.com/PolymerElements/paper-button/issues/64

Copying one of my comments from that issue here:


The issue is in `paper-button-behavior.html`:

    observers: [
      '_calculateElevation(focused, disabled, active, pressed, receivedFocusFromKeyboard)',
      '_computeKeyboardClass(receivedFocusFromKeyboard)'
    ],
    ...
     _computeKeyboardClass: function(receivedFocusFromKeyboard) {
      this.classList.toggle('keyboard-focus', receivedFocusFromKeyboard); // <- Right Here
    },

The observer uses `this.classList.toggle()` **BUT** the second boolean parameter isn't supported in IE / Opera 12-

If you swap out `this.classList.toggle()` with the utility function Polymer provides for the same purpose: `this.toggleClass()`, everything works fine. 