### PR TITLE
Add missing ref to paper-checked-element-behavior

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
   ],
   "main": [
     "paper-button-behavior.html",
+    "paper-checked-element-behavior.html",
     "paper-inky-focus-behavior.html"
   ],
   "keywords": [


### PR DESCRIPTION
... so docs will show up in the catalog.
Fixes #44.