### PR TITLE
Correct `noink` property to `no-ink` to actually conform to established property name conventions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-behaviors",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Common behaviors across the paper elements",
   "authors": [
     "The Polymer Authors"

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <!--
 @license
 Copyright (c) 2015 The Polymer Project Authors. All rights reserved.

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <!--
 @license
 Copyright (c) 2015 The Polymer Project Authors. All rights reserved.

--- a/paper-ripple-behavior.html
+++ b/paper-ripple-behavior.html
@@ -27,6 +27,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * If true, the element will not produce a ripple effect when interacted
        * with via the pointer.
        */
+      noInk: {
+        type: Boolean,
+        observer: '_noInkChanged'
+      },
+
+      /**
+       * This property is a temporary alias to noInk untl version 1.1
+       *
+       */
       noink: {
         type: Boolean,
         observer: '_noinkChanged'
@@ -70,7 +79,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     ensureRipple: function(optTriggeringEvent) {
       if (!this.hasRipple()) {
         this._ripple = this._createRipple();
-        this._ripple.noink = this.noink;
+        this._ripple.noInk = this.noInk;
         var rippleContainer = this._rippleContainer || this.root;
         if (rippleContainer) {
           Polymer.dom(rippleContainer).appendChild(this._ripple);
@@ -117,10 +126,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           document.createElement('paper-ripple'));
     },
 
-    _noinkChanged: function(noink) {
+    _noInkChanged: function(noInk) {
       if (this.hasRipple()) {
-        this._ripple.noink = noink;
+        this._ripple.noInk = noInk;
       }
-    }
+    },
+
+    noinkChanged: function(noInk) {
+      console.warn("This field is deprecated; starting with version 1.1");
+      this.noInk = noInk;
+    },
   };
 </script>


### PR DESCRIPTION
## The problem
While sorta "cute", `noink` seemingly seriously violates the conventions expected for property names that other elements conform to. Seeing no reason that it be a special exception, this PR changes the `noink` boolean property to `no-ink`

If `noink` is still used—or existing instances using this behavior are still using it— its observer will instead delegate the changes to the correct observers associated with of `no-ink` while providing a console warning that the use of `noink` is deprecated.

This enables the current behavior while informing consumers of this component that `noink` should no longer be relied on once `1.0` is bumped to `1.1`.

## Side-effects
- Version changed to `1.0.12`
- `console.warn` is used to warn consumers that the `no-ink` 
- The main file is slightly larger (8 lines) 

## Recommended reviewers
Motivated in a way by @notwaldorf about APIs (always wanted to go ahead and do this change but haven't had moments often that I *had* to rely on this behavior until now), it be awesome she reviewed it along with the other 3 recent reviewers of this repo:
- @cdata 
- @abdonrd 
-@keanulee

## Tests Pass?
Leveraged existing tests given the changes made; I can see an argument that `noInk` method be mocked & ensured to be called when `noink` is still used & so on…

## Estimated Review Time
- Estimated review time is 5-8 minutes. 