### PR TITLE
Don't have `return /** comment */` lines

### DIFF
--- a/paper-ripple-behavior.html
+++ b/paper-ripple-behavior.html
@@ -113,8 +113,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {!PaperRippleElement} Returns a `<paper-ripple>` element.
      */
     _createRipple: function() {
-      return /** @type {!PaperRippleElement} */ (
+      var element = /** @type {!PaperRippleElement} */ (
           document.createElement('paper-ripple'));
+      return element;
     },
 
     _noinkChanged: function(noink) {


### PR DESCRIPTION
This breaks espree AST generation with automatic semicolon insertion and
becomes

```
return
/** comment */
thing;
```

Refs https://github.com/Polymer/polymer/pull/4837