### PR TITLE
Import iron-button-state

### DIFF
--- a/paper-ripple-behavior.html
+++ b/paper-ripple-behavior.html
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-behaviors/iron-button-state.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 
 <script>


### PR DESCRIPTION
Paper ripple behavior uses Polymer.IronButtonStateImpl but doesn't (yet) import the file.
This means that the closure compiler doesn't see the data type.