### PR TITLE
Remove "Polymer" namespace on references to behaviors.

### DIFF
--- a/paper-button-behavior.js
+++ b/paper-button-behavior.js
@@ -15,7 +15,7 @@ import {IronControlState} from '@polymer/iron-behaviors/iron-control-state.js';
 
 import {PaperRippleBehavior} from './paper-ripple-behavior.js';
 
-/** @polymerBehavior Polymer.PaperButtonBehavior */
+/** @polymerBehavior PaperButtonBehavior */
 export const PaperButtonBehaviorImpl = {
   properties: {
     /**

--- a/paper-checked-element-behavior.js
+++ b/paper-checked-element-behavior.js
@@ -16,10 +16,10 @@ import {PaperInkyFocusBehavior} from './paper-inky-focus-behavior.js';
 import {PaperRippleBehavior} from './paper-ripple-behavior.js';
 
 /**
- * Use `Polymer.PaperCheckedElementBehavior` to implement a custom element
- * that has a `checked` property similar to `Polymer.IronCheckedElementBehavior`
- * and is compatible with having a ripple effect.
- * @polymerBehavior Polymer.PaperCheckedElementBehavior
+ * Use `PaperCheckedElementBehavior` to implement a custom element that has a
+ * `checked` property similar to `IronCheckedElementBehavior` and is compatible
+ * with having a ripple effect.
+ * @polymerBehavior PaperCheckedElementBehavior
  */
 export const PaperCheckedElementBehaviorImpl = {
   /**
@@ -50,7 +50,7 @@ export const PaperCheckedElementBehaviorImpl = {
   }
 };
 
-/** @polymerBehavior Polymer.PaperCheckedElementBehavior */
+/** @polymerBehavior */
 export const PaperCheckedElementBehavior = [
   PaperInkyFocusBehavior,
   IronCheckedElementBehavior,

--- a/paper-inky-focus-behavior.js
+++ b/paper-inky-focus-behavior.js
@@ -16,10 +16,10 @@ import {IronControlState} from '@polymer/iron-behaviors/iron-control-state.js';
 import {PaperRippleBehavior} from './paper-ripple-behavior.js';
 
 /**
- * `Polymer.PaperInkyFocusBehavior` implements a ripple when the element has
- * keyboard focus.
+ * `PaperInkyFocusBehavior` implements a ripple when the element has keyboard
+ * focus.
  *
- * @polymerBehavior Polymer.PaperInkyFocusBehavior
+ * @polymerBehavior PaperInkyFocusBehavior
  */
 export const PaperInkyFocusBehaviorImpl = {
   observers: ['_focusedChanged(receivedFocusFromKeyboard)'],
@@ -42,7 +42,7 @@ export const PaperInkyFocusBehaviorImpl = {
   }
 };
 
-/** @polymerBehavior Polymer.PaperInkyFocusBehavior */
+/** @polymerBehavior */
 export const PaperInkyFocusBehavior = [
   IronButtonState,
   IronControlState,

--- a/paper-ripple-behavior.js
+++ b/paper-ripple-behavior.js
@@ -15,13 +15,13 @@ import {IronButtonStateImpl} from '@polymer/iron-behaviors/iron-button-state.js'
 import {dom} from '@polymer/polymer/lib/legacy/polymer.dom.js';
 
 /**
- * `Polymer.PaperRippleBehavior` dynamically implements a ripple
- * when the element has focus via pointer or keyboard.
+ * `PaperRippleBehavior` dynamically implements a ripple when the element has
+ * focus via pointer or keyboard.
  *
  * NOTE: This behavior is intended to be used in conjunction with and after
- * `Polymer.IronButtonState` and `Polymer.IronControlState`.
+ * `IronButtonState` and `IronControlState`.
  *
- * @polymerBehavior Polymer.PaperRippleBehavior
+ * @polymerBehavior PaperRippleBehavior
  */
 export const PaperRippleBehavior = {
   properties: {


### PR DESCRIPTION
Because it doesn't exist anymore, and this confuses Analyzer.